### PR TITLE
Drop services that are failing

### DIFF
--- a/pura/resolvers.py
+++ b/pura/resolvers.py
@@ -20,7 +20,7 @@ from typing import Optional, List, Union, Tuple, Dict, Callable
 from itertools import combinations
 from functools import reduce
 import logging
-import queue
+import numpy as np
 
 try:
     nest_asyncio.apply()
@@ -172,12 +172,14 @@ class CompoundResolver:
         services: List[Service],
         silent: Optional[bool] = False,
         agreement_check: Optional[Callable] = None,
+        service_failures_threshold: Optional[int] = 10,
     ):
         self._services = services
         self.silent = silent
         self.agreement_check = (
             agreement_check if agreement_check is not None else base_check_agreement
         )
+        self.service_failures_threshold = service_failures_threshold
 
     def resolve(
         self,
@@ -212,7 +214,10 @@ class CompoundResolver:
         n_retries : int, optional
             The number of times a request should be retried if there is a problem
             in contacting a service (e.g., an internet outage). Defaults to 3.
-
+        service_failures_threshold : int, optional
+            The number of failures that can occur on a particular service before that service
+            is no longer used. This is useful for cases where a serviceis down for a long period of time.
+            Defaults to 10.
 
         Notes
         -----
@@ -268,7 +273,7 @@ class CompoundResolver:
         """This is the async function with the same API as resolve"""
 
         # Run setup for services
-        for service in self._services:
+        for service in self.services:
             await service.setup()
 
         n_identifiers = len(input_compounds)
@@ -317,7 +322,7 @@ class CompoundResolver:
                 resolved_identifiers.extend([await f for f in batch_bar])
                 batch_bar.clear()
 
-        for service in self._services:
+        for service in self.services:
             await service.teardown()
 
         return resolved_identifiers
@@ -334,18 +339,16 @@ class CompoundResolver:
         """Resolve one compound"""
         resolved_identifiers_list = []
         agreement_satisfied = False
-        # Create input identifier queue
+        # Create input identifier list
         input_identifiers_list = [
             (identifier, None) for identifier in input_compound.identifiers
         ]
-        # for identifier in input_compound.identifiers:
-        #     input_identifiers_queue.put()
 
         # Main loop
         while len(input_identifiers_list) > 0 and not agreement_satisfied:
             input_identifier, no_go_service = input_identifiers_list[0]
             input_identifiers_list = input_identifiers_list[1:]
-            for service in self._services:
+            for service in self.services:
                 if service == no_go_service:
                     continue
                 for j in range(n_retries):
@@ -390,9 +393,11 @@ class CompoundResolver:
                     except aiohttp_errors as e:  # type: ignore
                         # If server is busy, use exponential backoff
                         logger.debug(f"Sleeping for {2**j} ({e})")
+                        service.n_failures += 1
                         await asyncio.sleep(2**j)
                     except (HTTPClientError, HTTPServerError) as e:
                         # Log/raise on all other HTTP errors
+                        service.n_failures += 1
                         if self.silent:
                             logger.error(msg=f"{service}, {input_identifier}: {e}")
                             break
@@ -441,6 +446,16 @@ class CompoundResolver:
             else:
                 raise ResolverError(error_txt)
         return input_compound, flatten_list(resolved_identifiers_list)
+
+    @property
+    def services(self):
+        """Return services"""
+        threshold = (
+            self.service_failures_threshold
+            if self.service_failures_threshold
+            else np.inf
+        )
+        return [service for service in self._services if service.n_failures < threshold]
 
 
 def flatten_list(l: List):

--- a/pura/resolvers.py
+++ b/pura/resolvers.py
@@ -344,6 +344,12 @@ class CompoundResolver:
             (identifier, None) for identifier in input_compound.identifiers
         ]
 
+        threshold = (
+            self.service_failures_threshold
+            if self.service_failures_threshold is not None
+            else np.inf
+        )
+
         # Main loop
         while len(input_identifiers_list) > 0 and not agreement_satisfied:
             input_identifier, no_go_service = input_identifiers_list[0]
@@ -352,6 +358,8 @@ class CompoundResolver:
                 if service == no_go_service:
                     continue
                 for j in range(n_retries):
+                    if service.n_failures >= threshold:
+                        break
                     try:
                         output_identifier_types = [
                             output_identifier_type
@@ -450,12 +458,7 @@ class CompoundResolver:
     @property
     def services(self):
         """Return services"""
-        threshold = (
-            self.service_failures_threshold
-            if self.service_failures_threshold
-            else np.inf
-        )
-        return [service for service in self._services if service.n_failures < threshold]
+        return self._services
 
 
 def flatten_list(l: List):

--- a/pura/resolvers.py
+++ b/pura/resolvers.py
@@ -216,7 +216,7 @@ class CompoundResolver:
             in contacting a service (e.g., an internet outage). Defaults to 3.
         service_failures_threshold : int, optional
             The number of failures that can occur on a particular service before that service
-            is no longer used. This is useful for cases where a serviceis down for a long period of time.
+            is no longer used. This is useful for cases where a service is down for a long period of time.
             Defaults to 10.
 
         Notes

--- a/pura/services/service.py
+++ b/pura/services/service.py
@@ -2,27 +2,11 @@ from pura.compound import CompoundIdentifier, CompoundIdentifierType
 from aiohttp import ClientSession
 from abc import ABC, abstractmethod
 from typing import List, Union
-from functools import wraps
-import time
-
-
-def timeit(func):
-    @wraps(func)
-    def timeit_wrapper(*args, **kwargs):
-        start_time = time.perf_counter()
-        result = func(*args, **kwargs)
-        end_time = time.perf_counter()
-        total_time = end_time - start_time
-        # first item in the args, ie `args[0]` is `self`
-        print(f"Function {func.__name__}{args} {kwargs} Took {total_time:.4f} seconds")
-        return result
-
-    return timeit_wrapper
 
 
 class Service(ABC):
     def __init__(self) -> None:
-        pass
+        self.n_failures = 0
 
     async def setup(self):
         pass
@@ -31,7 +15,6 @@ class Service(ABC):
         pass
 
     @abstractmethod
-    @timeit
     async def resolve_compound(
         self,
         session: ClientSession,
@@ -39,3 +22,6 @@ class Service(ABC):
         output_identifier_types: List[CompoundIdentifierType],
     ) -> List[Union[CompoundIdentifier, None]]:
         pass
+
+    def reset(self):
+        self.n_failures = 0

--- a/pura/services/service.py
+++ b/pura/services/service.py
@@ -2,6 +2,22 @@ from pura.compound import CompoundIdentifier, CompoundIdentifierType
 from aiohttp import ClientSession
 from abc import ABC, abstractmethod
 from typing import List, Union
+from functools import wraps
+import time
+
+
+def timeit(func):
+    @wraps(func)
+    def timeit_wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        total_time = end_time - start_time
+        # first item in the args, ie `args[0]` is `self`
+        print(f"Function {func.__name__}{args} {kwargs} Took {total_time:.4f} seconds")
+        return result
+
+    return timeit_wrapper
 
 
 class Service(ABC):
@@ -15,6 +31,7 @@ class Service(ABC):
         pass
 
     @abstractmethod
+    @timeit
     async def resolve_compound(
         self,
         session: ClientSession,

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -54,7 +54,7 @@ def test_resolve_backup_identifiers():
             CompoundIdentifierType.INCHI_KEY,
             CompoundIdentifierType.CAS_NUMBER,
         ],
-        services=[PubChem(autocomplete=False), CIR(), CAS(), ChemSpider()],
+        services=[PubChem(autocomplete=False), CIR(), CAS()],
         agreement=1,
         silent=True,
     )
@@ -135,25 +135,25 @@ async def async_test_pubchem():
         print(resolved)
 
 
-def test_chempsider():
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_test_chempsider())
+# def test_chempsider():
+#     loop = asyncio.get_event_loop()
+#     loop.run_until_complete(async_test_chempsider())
 
 
-async def async_test_chempsider():
-    async with ClientSession() as session:
-        service = ChemSpider()
-        resolved = await service.resolve_compound(
-            session=session,
-            input_identifier=CompoundIdentifier(
-                identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
-            ),
-            output_identifier_types=[
-                CompoundIdentifierType.SMILES,
-                CompoundIdentifierType.INCHI_KEY,
-            ],
-        )
-        print(resolved)
+# async def async_test_chempsider():
+#     async with ClientSession() as session:
+#         service = ChemSpider()
+#         resolved = await service.resolve_compound(
+#             session=session,
+#             input_identifier=CompoundIdentifier(
+#                 identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
+#             ),
+#             output_identifier_types=[
+#                 CompoundIdentifierType.SMILES,
+#                 CompoundIdentifierType.INCHI_KEY,
+#             ],
+#         )
+#         print(resolved)
 
 
 def test_cas():

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -56,7 +56,7 @@ def test_compound_resolver_service_failure(mock_working_service, mock_failing_se
         for name in example_names
     ]
 
-    # Test services failures threshold
+    # Test service failures threshold
     threshold = 10
     resolver = CompoundResolver(
         services=[mock_failing_service, mock_working_service],

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -73,137 +73,116 @@ def test_compound_resolver_service_failure(mock_working_service, mock_failing_se
     assert mock_working_service.resolve_compound.call_count == len(compounds)
 
 
-@pytest.mark.parametrize("identifier_type", OUTPUT_IDENTIFIER_MAP)
-def test_resolve_identifiers_no_agreement(identifier_type):
-    resolved = resolve_identifiers(
-        ["Josiphos SL-J001-1"],
-        input_identifer_type=CompoundIdentifierType.NAME,
-        output_identifier_type=identifier_type,
-        services=[
-            PubChem(),
-            # CIR(),
-        ],
-        agreement=0,
-    )
-    print(resolved)
-    # correct_smiles = (
-    #     "CC(C1CCCC1P(C2=CC=CC=C2)C3=CC=CC=C3)P(C4CCCCC4)C5CCCCC5.C1CCCC1.[Fe]"
-    # )
-    # correct_inchi = "ULNUEACLWYUUMO-UHFFFAOYSA-N"
-    # # correct_smiles = Chem.CanonSmiles(correct_smiles)
-    # input_compound, resolved_identifiers = resolved[0]
-    # assert resolved_identifiers[0].value == correct_inchi
+# @pytest.mark.parametrize("identifier_type", OUTPUT_IDENTIFIER_MAP)
+# def test_resolve_identifiers_no_agreement(identifier_type):
+#     resolved = resolve_identifiers(
+#         ["Josiphos SL-J001-1"],
+#         input_identifer_type=CompoundIdentifierType.NAME,
+#         output_identifier_type=identifier_type,
+#         services=[
+#             PubChem(),
+#             # CIR(),
+#         ],
+#         agreement=0,
+#     )
+#     print(resolved)
+#     # correct_smiles = (
+#     #     "CC(C1CCCC1P(C2=CC=CC=C2)C3=CC=CC=C3)P(C4CCCCC4)C5CCCCC5.C1CCCC1.[Fe]"
+#     # )
+#     # correct_inchi = "ULNUEACLWYUUMO-UHFFFAOYSA-N"
+#     # # correct_smiles = Chem.CanonSmiles(correct_smiles)
+#     # input_compound, resolved_identifiers = resolved[0]
+#     # assert resolved_identifiers[0].value == correct_inchi
 
 
-def test_resolve_backup_identifiers():
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    logger = logging.getLogger(__name__)
-    resolved = resolve_identifiers(
-        [
-            "Pd(OAc)2",
-            # "Josiphos SL-J001-1",
-            # "Rh(NBD)2BF4",
-            # "Dichloro(p-cymene)ruthenium(II) dimer",
-            # "DuPhos",
-        ],
-        input_identifer_type=CompoundIdentifierType.NAME,
-        output_identifier_type=CompoundIdentifierType.SMILES,
-        backup_identifier_types=[
-            CompoundIdentifierType.INCHI_KEY,
-            CompoundIdentifierType.CAS_NUMBER,
-        ],
-        services=[PubChem(autocomplete=False), CIR(), CAS()],
-        agreement=1,
-        silent=True,
-    )
-    print("\nResults\n")
-    for input_compound, resolved_identifiers in resolved:
-        print(input_compound, resolved_identifiers, "\n")
+# def test_resolve_backup_identifiers():
+#     logging.basicConfig(
+#         level=logging.DEBUG,
+#         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+#     )
+#     logger = logging.getLogger(__name__)
+#     resolved = resolve_identifiers(
+#         [
+#             "Pd(OAc)2",
+#             # "Josiphos SL-J001-1",
+#             # "Rh(NBD)2BF4",
+#             # "Dichloro(p-cymene)ruthenium(II) dimer",
+#             # "DuPhos",
+#         ],
+#         input_identifer_type=CompoundIdentifierType.NAME,
+#         output_identifier_type=CompoundIdentifierType.SMILES,
+#         backup_identifier_types=[
+#             CompoundIdentifierType.INCHI_KEY,
+#             CompoundIdentifierType.CAS_NUMBER,
+#         ],
+#         services=[PubChem(autocomplete=False), CIR(), CAS()],
+#         agreement=1,
+#         silent=True,
+#     )
+#     print("\nResults\n")
+#     for input_compound, resolved_identifiers in resolved:
+#         print(input_compound, resolved_identifiers, "\n")
 
 
-# Josiphos SL-J001-1 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1CCCC1.CC(C1CCCC1P(c1ccccc1)c1ccccc1)P(C1CCCCC1)C1CCCCC1.[Fe]', details=None)]
+# # Josiphos SL-J001-1 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1CCCC1.CC(C1CCCC1P(c1ccccc1)c1ccccc1)P(C1CCCCC1)C1CCCCC1.[Fe]', details=None)]
 
-# Rh(NBD)2BF4 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1=CC2C=CC1C2.C1=CC2C=CC1C2.F[B-](F)(F)F.[Rh]', details=None)]
+# # Rh(NBD)2BF4 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1=CC2C=CC1C2.C1=CC2C=CC1C2.F[B-](F)(F)F.[Rh]', details=None)]
 
-# Dichloro(p-cymene)ruthenium(II) dimer [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='Cc1ccc(C(C)C)cc1.Cc1ccc(C(C)C)cc1.Cl[Ru]Cl.Cl[Ru]Cl', details=None)]
+# # Dichloro(p-cymene)ruthenium(II) dimer [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='Cc1ccc(C(C)C)cc1.Cc1ccc(C(C)C)cc1.Cl[Ru]Cl.Cl[Ru]Cl', details=None)]
 
-# DuPhos [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='CC(C)C1CCC(C(C)C)P1c1ccccc1P1C(C(C)C)CCC1C(C)C', details=None)]
-
-
-def test_cir():
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_test_cir())
+# # DuPhos [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='CC(C)C1CCC(C(C)C)P1c1ccccc1P1C(C(C)C)CCC1C(C)C', details=None)]
 
 
-async def async_test_cir():
-    async with ClientSession() as session:
-        service = CIR(specify_input_identifier_type=True)
-        resolved = await service.resolve_compound(
-            session=session,
-            input_identifier=CompoundIdentifier(
-                identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
-            ),
-            output_identifier_types=[
-                CompoundIdentifierType.SMILES,
-                CompoundIdentifierType.INCHI_KEY,
-            ],
-        )
-        print(resolved)
-
-
-def test_opsin():
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_test_opsin())
-
-
-async def async_test_opsin():
-    async with ClientSession() as session:
-        service = Opsin()
-        resolved = await service.resolve_compound(
-            session=session,
-            input_identifier=CompoundIdentifier(
-                identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
-            ),
-            output_identifier_types=[
-                CompoundIdentifierType.SMILES,
-                CompoundIdentifierType.INCHI_KEY,
-            ],
-        )
-        print(resolved)
-
-
-def test_pubchem():
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_test_pubchem())
-
-
-async def async_test_pubchem():
-    async with ClientSession() as session:
-        service = PubChem()
-        resolved = await service.resolve_compound(
-            session=session,
-            input_identifier=CompoundIdentifier(
-                identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
-            ),
-            output_identifier_types=[
-                CompoundIdentifierType.SMILES,
-                CompoundIdentifierType.INCHI_KEY,
-            ],
-        )
-        print(resolved)
-
-
-# def test_chempsider():
+# def test_cir():
 #     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_chempsider())
+#     loop.run_until_complete(async_test_cir())
 
 
-# async def async_test_chempsider():
+# async def async_test_cir():
 #     async with ClientSession() as session:
-#         service = ChemSpider()
+#         service = CIR(specify_input_identifier_type=True)
+#         resolved = await service.resolve_compound(
+#             session=session,
+#             input_identifier=CompoundIdentifier(
+#                 identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
+#             ),
+#             output_identifier_types=[
+#                 CompoundIdentifierType.SMILES,
+#                 CompoundIdentifierType.INCHI_KEY,
+#             ],
+#         )
+#         print(resolved)
+
+
+# def test_opsin():
+#     loop = asyncio.get_event_loop()
+#     loop.run_until_complete(async_test_opsin())
+
+
+# async def async_test_opsin():
+#     async with ClientSession() as session:
+#         service = Opsin()
+#         resolved = await service.resolve_compound(
+#             session=session,
+#             input_identifier=CompoundIdentifier(
+#                 identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
+#             ),
+#             output_identifier_types=[
+#                 CompoundIdentifierType.SMILES,
+#                 CompoundIdentifierType.INCHI_KEY,
+#             ],
+#         )
+#         print(resolved)
+
+
+# def test_pubchem():
+#     loop = asyncio.get_event_loop()
+#     loop.run_until_complete(async_test_pubchem())
+
+
+# async def async_test_pubchem():
+#     async with ClientSession() as session:
+#         service = PubChem()
 #         resolved = await service.resolve_compound(
 #             session=session,
 #             input_identifier=CompoundIdentifier(
@@ -217,25 +196,46 @@ async def async_test_pubchem():
 #         print(resolved)
 
 
-def test_cas():
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_test_cas())
+# # def test_chempsider():
+# #     loop = asyncio.get_event_loop()
+# #     loop.run_until_complete(async_test_chempsider())
 
 
-async def async_test_cas():
-    async with ClientSession() as session:
-        service = CAS()
-        resolved = await service.resolve_compound(
-            session=session,
-            input_identifier=CompoundIdentifier(
-                identifier_type=CompoundIdentifierType.CAS_NUMBER, value="108-88-3"
-            ),
-            output_identifier_types=[
-                CompoundIdentifierType.SMILES,
-                CompoundIdentifierType.INCHI_KEY,
-            ],
-        )
-        print(resolved)
+# # async def async_test_chempsider():
+# #     async with ClientSession() as session:
+# #         service = ChemSpider()
+# #         resolved = await service.resolve_compound(
+# #             session=session,
+# #             input_identifier=CompoundIdentifier(
+# #                 identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
+# #             ),
+# #             output_identifier_types=[
+# #                 CompoundIdentifierType.SMILES,
+# #                 CompoundIdentifierType.INCHI_KEY,
+# #             ],
+# #         )
+# #         print(resolved)
+
+
+# def test_cas():
+#     loop = asyncio.get_event_loop()
+#     loop.run_until_complete(async_test_cas())
+
+
+# async def async_test_cas():
+#     async with ClientSession() as session:
+#         service = CAS()
+#         resolved = await service.resolve_compound(
+#             session=session,
+#             input_identifier=CompoundIdentifier(
+#                 identifier_type=CompoundIdentifierType.CAS_NUMBER, value="108-88-3"
+#             ),
+#             output_identifier_types=[
+#                 CompoundIdentifierType.SMILES,
+#                 CompoundIdentifierType.INCHI_KEY,
+#             ],
+#         )
+#         print(resolved)
 
 
 # if __name__ == "__main__":

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,180 +1,180 @@
-# import asyncio
-# import pytest
-# from pura.resolvers import resolve_identifiers, CompoundResolver
-# from pura.compound import Compound, CompoundIdentifier, CompoundIdentifierType
-# from pura.services import CIR, Opsin, ChemSpider, CAS
-# from pura.services.pubchem import PubChem, OUTPUT_IDENTIFIER_MAP, autocomplete
-# from rdkit import Chem
-# from aiohttp import *
-# from dotenv import load_dotenv
-# import logging
+import asyncio
+import pytest
+from pura.resolvers import resolve_identifiers, CompoundResolver
+from pura.compound import Compound, CompoundIdentifier, CompoundIdentifierType
+from pura.services import CIR, Opsin, ChemSpider, CAS
+from pura.services.pubchem import PubChem, OUTPUT_IDENTIFIER_MAP, autocomplete
+from rdkit import Chem
+from aiohttp import *
+from dotenv import load_dotenv
+import logging
 
-# load_dotenv()
-
-
-# @pytest.mark.parametrize("identifier_type", OUTPUT_IDENTIFIER_MAP)
-# def test_resolve_identifiers_no_agreement(identifier_type):
-#     resolved = resolve_identifiers(
-#         ["Josiphos SL-J001-1"],
-#         input_identifer_type=CompoundIdentifierType.NAME,
-#         output_identifier_type=identifier_type,
-#         services=[
-#             PubChem(),
-#             # CIR(),
-#         ],
-#         agreement=0,
-#     )
-#     print(resolved)
-#     # correct_smiles = (
-#     #     "CC(C1CCCC1P(C2=CC=CC=C2)C3=CC=CC=C3)P(C4CCCCC4)C5CCCCC5.C1CCCC1.[Fe]"
-#     # )
-#     # correct_inchi = "ULNUEACLWYUUMO-UHFFFAOYSA-N"
-#     # # correct_smiles = Chem.CanonSmiles(correct_smiles)
-#     # input_compound, resolved_identifiers = resolved[0]
-#     # assert resolved_identifiers[0].value == correct_inchi
+load_dotenv()
 
 
-# def test_resolve_backup_identifiers():
-#     logging.basicConfig(
-#         level=logging.DEBUG,
-#         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-#     )
-#     logger = logging.getLogger(__name__)
-#     resolved = resolve_identifiers(
-#         [
-#             "Pd(OAc)2",
-#             # "Josiphos SL-J001-1",
-#             # "Rh(NBD)2BF4",
-#             # "Dichloro(p-cymene)ruthenium(II) dimer",
-#             # "DuPhos",
-#         ],
-#         input_identifer_type=CompoundIdentifierType.NAME,
-#         output_identifier_type=CompoundIdentifierType.SMILES,
-#         backup_identifier_types=[
-#             CompoundIdentifierType.INCHI_KEY,
-#             CompoundIdentifierType.CAS_NUMBER,
-#         ],
-#         services=[PubChem(autocomplete=False), CIR(), CAS(), ChemSpider()],
-#         agreement=1,
-#         silent=True,
-#     )
-#     print("\nResults\n")
-#     for input_compound, resolved_identifiers in resolved:
-#         print(input_compound, resolved_identifiers, "\n")
+@pytest.mark.parametrize("identifier_type", OUTPUT_IDENTIFIER_MAP)
+def test_resolve_identifiers_no_agreement(identifier_type):
+    resolved = resolve_identifiers(
+        ["Josiphos SL-J001-1"],
+        input_identifer_type=CompoundIdentifierType.NAME,
+        output_identifier_type=identifier_type,
+        services=[
+            PubChem(),
+            # CIR(),
+        ],
+        agreement=0,
+    )
+    print(resolved)
+    # correct_smiles = (
+    #     "CC(C1CCCC1P(C2=CC=CC=C2)C3=CC=CC=C3)P(C4CCCCC4)C5CCCCC5.C1CCCC1.[Fe]"
+    # )
+    # correct_inchi = "ULNUEACLWYUUMO-UHFFFAOYSA-N"
+    # # correct_smiles = Chem.CanonSmiles(correct_smiles)
+    # input_compound, resolved_identifiers = resolved[0]
+    # assert resolved_identifiers[0].value == correct_inchi
 
 
-# # Josiphos SL-J001-1 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1CCCC1.CC(C1CCCC1P(c1ccccc1)c1ccccc1)P(C1CCCCC1)C1CCCCC1.[Fe]', details=None)]
-
-# # Rh(NBD)2BF4 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1=CC2C=CC1C2.C1=CC2C=CC1C2.F[B-](F)(F)F.[Rh]', details=None)]
-
-# # Dichloro(p-cymene)ruthenium(II) dimer [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='Cc1ccc(C(C)C)cc1.Cc1ccc(C(C)C)cc1.Cl[Ru]Cl.Cl[Ru]Cl', details=None)]
-
-# # DuPhos [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='CC(C)C1CCC(C(C)C)P1c1ccccc1P1C(C(C)C)CCC1C(C)C', details=None)]
-
-
-# def test_cir():
-#     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_cir())
-
-
-# async def async_test_cir():
-#     async with ClientSession() as session:
-#         service = CIR(specify_input_identifier_type=True)
-#         resolved = await service.resolve_compound(
-#             session=session,
-#             input_identifier=CompoundIdentifier(
-#                 identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
-#             ),
-#             output_identifier_types=[
-#                 CompoundIdentifierType.SMILES,
-#                 CompoundIdentifierType.INCHI_KEY,
-#             ],
-#         )
-#         print(resolved)
-
-
-# def test_opsin():
-#     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_opsin())
+def test_resolve_backup_identifiers():
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+    resolved = resolve_identifiers(
+        [
+            "Pd(OAc)2",
+            # "Josiphos SL-J001-1",
+            # "Rh(NBD)2BF4",
+            # "Dichloro(p-cymene)ruthenium(II) dimer",
+            # "DuPhos",
+        ],
+        input_identifer_type=CompoundIdentifierType.NAME,
+        output_identifier_type=CompoundIdentifierType.SMILES,
+        backup_identifier_types=[
+            CompoundIdentifierType.INCHI_KEY,
+            CompoundIdentifierType.CAS_NUMBER,
+        ],
+        services=[PubChem(autocomplete=False), CIR(), CAS(), ChemSpider()],
+        agreement=1,
+        silent=True,
+    )
+    print("\nResults\n")
+    for input_compound, resolved_identifiers in resolved:
+        print(input_compound, resolved_identifiers, "\n")
 
 
-# async def async_test_opsin():
-#     async with ClientSession() as session:
-#         service = Opsin()
-#         resolved = await service.resolve_compound(
-#             session=session,
-#             input_identifier=CompoundIdentifier(
-#                 identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
-#             ),
-#             output_identifier_types=[
-#                 CompoundIdentifierType.SMILES,
-#                 CompoundIdentifierType.INCHI_KEY,
-#             ],
-#         )
-#         print(resolved)
+# Josiphos SL-J001-1 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1CCCC1.CC(C1CCCC1P(c1ccccc1)c1ccccc1)P(C1CCCCC1)C1CCCCC1.[Fe]', details=None)]
+
+# Rh(NBD)2BF4 [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='C1=CC2C=CC1C2.C1=CC2C=CC1C2.F[B-](F)(F)F.[Rh]', details=None)]
+
+# Dichloro(p-cymene)ruthenium(II) dimer [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='Cc1ccc(C(C)C)cc1.Cc1ccc(C(C)C)cc1.Cl[Ru]Cl.Cl[Ru]Cl', details=None)]
+
+# DuPhos [CompoundIdentifier(identifier_type=<CompoundIdentifierType.SMILES: 2>, value='CC(C)C1CCC(C(C)C)P1c1ccccc1P1C(C(C)C)CCC1C(C)C', details=None)]
 
 
-# def test_pubchem():
-#     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_pubchem())
+def test_cir():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_test_cir())
 
 
-# async def async_test_pubchem():
-#     async with ClientSession() as session:
-#         service = PubChem()
-#         resolved = await service.resolve_compound(
-#             session=session,
-#             input_identifier=CompoundIdentifier(
-#                 identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
-#             ),
-#             output_identifier_types=[
-#                 CompoundIdentifierType.SMILES,
-#                 CompoundIdentifierType.INCHI_KEY,
-#             ],
-#         )
-#         print(resolved)
+async def async_test_cir():
+    async with ClientSession() as session:
+        service = CIR(specify_input_identifier_type=True)
+        resolved = await service.resolve_compound(
+            session=session,
+            input_identifier=CompoundIdentifier(
+                identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
+            ),
+            output_identifier_types=[
+                CompoundIdentifierType.SMILES,
+                CompoundIdentifierType.INCHI_KEY,
+            ],
+        )
+        print(resolved)
 
 
-# def test_chempsider():
-#     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_chempsider())
+def test_opsin():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_test_opsin())
 
 
-# async def async_test_chempsider():
-#     async with ClientSession() as session:
-#         service = ChemSpider()
-#         resolved = await service.resolve_compound(
-#             session=session,
-#             input_identifier=CompoundIdentifier(
-#                 identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
-#             ),
-#             output_identifier_types=[
-#                 CompoundIdentifierType.SMILES,
-#                 CompoundIdentifierType.INCHI_KEY,
-#             ],
-#         )
-#         print(resolved)
+async def async_test_opsin():
+    async with ClientSession() as session:
+        service = Opsin()
+        resolved = await service.resolve_compound(
+            session=session,
+            input_identifier=CompoundIdentifier(
+                identifier_type=CompoundIdentifierType.NAME, value="methylbenzene"
+            ),
+            output_identifier_types=[
+                CompoundIdentifierType.SMILES,
+                CompoundIdentifierType.INCHI_KEY,
+            ],
+        )
+        print(resolved)
 
 
-# def test_cas():
-#     loop = asyncio.get_event_loop()
-#     loop.run_until_complete(async_test_cas())
+def test_pubchem():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_test_pubchem())
 
 
-# async def async_test_cas():
-#     async with ClientSession() as session:
-#         service = CAS()
-#         resolved = await service.resolve_compound(
-#             session=session,
-#             input_identifier=CompoundIdentifier(
-#                 identifier_type=CompoundIdentifierType.CAS_NUMBER, value="108-88-3"
-#             ),
-#             output_identifier_types=[
-#                 CompoundIdentifierType.SMILES,
-#                 CompoundIdentifierType.INCHI_KEY,
-#             ],
-#         )
-#         print(resolved)
+async def async_test_pubchem():
+    async with ClientSession() as session:
+        service = PubChem()
+        resolved = await service.resolve_compound(
+            session=session,
+            input_identifier=CompoundIdentifier(
+                identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
+            ),
+            output_identifier_types=[
+                CompoundIdentifierType.SMILES,
+                CompoundIdentifierType.INCHI_KEY,
+            ],
+        )
+        print(resolved)
+
+
+def test_chempsider():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_test_chempsider())
+
+
+async def async_test_chempsider():
+    async with ClientSession() as session:
+        service = ChemSpider()
+        resolved = await service.resolve_compound(
+            session=session,
+            input_identifier=CompoundIdentifier(
+                identifier_type=CompoundIdentifierType.NAME, value="Josiphos SL-J001-1"
+            ),
+            output_identifier_types=[
+                CompoundIdentifierType.SMILES,
+                CompoundIdentifierType.INCHI_KEY,
+            ],
+        )
+        print(resolved)
+
+
+def test_cas():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_test_cas())
+
+
+async def async_test_cas():
+    async with ClientSession() as session:
+        service = CAS()
+        resolved = await service.resolve_compound(
+            session=session,
+            input_identifier=CompoundIdentifier(
+                identifier_type=CompoundIdentifierType.CAS_NUMBER, value="108-88-3"
+            ),
+            output_identifier_types=[
+                CompoundIdentifierType.SMILES,
+                CompoundIdentifierType.INCHI_KEY,
+            ],
+        )
+        print(resolved)
 
 
 # if __name__ == "__main__":

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -2,14 +2,75 @@ import asyncio
 import pytest
 from pura.resolvers import resolve_identifiers, CompoundResolver
 from pura.compound import Compound, CompoundIdentifier, CompoundIdentifierType
-from pura.services import CIR, Opsin, ChemSpider, CAS
+from pura.services import CIR, Opsin, ChemSpider, CAS, Service
 from pura.services.pubchem import PubChem, OUTPUT_IDENTIFIER_MAP, autocomplete
 from rdkit import Chem
 from aiohttp import *
 from dotenv import load_dotenv
 import logging
+from unittest.mock import AsyncMock
+
 
 load_dotenv()
+
+
+@pytest.fixture
+def mock_failing_service():
+    mock = AsyncMock(spec=Service)
+    mock.n_failures = 0
+    mock.resolve_compound.side_effect = TimeoutError
+    return mock
+
+
+@pytest.fixture
+def mock_working_service():
+    mock = AsyncMock(spec=Service)
+    mock.n_failures = 0
+    mock.resolve_compound.return_value = [
+        CompoundIdentifier(
+            identifier_type=CompoundIdentifierType.SMILES,
+            value="O",
+        )
+    ]
+    return mock
+
+
+example_names = [
+    "Pd(OAc)2",
+    "Josiphos SL-J001-1",
+    "Rh(NBD)2BF4",
+    "Dichloro(p-cymene)ruthenium(II) dimer",
+    "DuPhos",
+]
+
+
+def test_compound_resolver_service_failure(mock_working_service, mock_failing_service):
+    compounds = [
+        Compound(
+            identifiers=[
+                CompoundIdentifier(
+                    identifier_type=CompoundIdentifierType.NAME, value=name
+                )
+            ]
+        )
+        for name in example_names
+    ]
+
+    # Test services failures threshold
+    threshold = 10
+    resolver = CompoundResolver(
+        services=[mock_failing_service, mock_working_service],
+        service_failures_threshold=threshold,
+    )
+    resolver.resolve(
+        compounds,
+        input_identifier_type=CompoundIdentifierType.NAME,
+        output_identifier_type=CompoundIdentifierType.SMILES,
+        backup_identifier_types=[],
+        agreement=1,
+    )
+    assert mock_failing_service.resolve_compound.call_count == threshold
+    assert mock_working_service.resolve_compound.call_count == len(compounds)
 
 
 @pytest.mark.parametrize("identifier_type", OUTPUT_IDENTIFIER_MAP)


### PR DESCRIPTION
This fixes #26 by dropping services that take a long time to resolve consistently. The idea is to track the number of failures  and then stop using a service if it passes a  threshold for the number of failures.

- [x] Implementation
- [x] Docs
- [x] Tests